### PR TITLE
Make Apify a standalone library

### DIFF
--- a/app/controllers/ErrorController.php
+++ b/app/controllers/ErrorController.php
@@ -15,11 +15,11 @@ class ErrorController
         // get the Exception from the Response
         $exception = $response->getException();
         switch ($exception->getCode()) { 
-            case Response::NOT_FOUND:
+            case Apify_Response::NOT_FOUND:
                 // 404 error - controller or action not found
                 $viewScript = 'pagenotfound';
                 break;
-            case Response::NOT_ACCEPTABLE:
+            case Apify_Response::NOT_ACCEPTABLE:
                 // 406 error - content type missing or invalid
                 break;
             default: 
@@ -28,7 +28,7 @@ class ErrorController
         }
         
         if ('html' === $request->getContentType()) {
-            $view = new View();
+            $view = new Apify_View();
             $view->setScript($viewScript);
             $view->setLayout('error');
             $response->setView($view);

--- a/app/controllers/IndexController.php
+++ b/app/controllers/IndexController.php
@@ -1,11 +1,11 @@
 <?php
-class IndexController extends Controller
+class IndexController extends Apify_Controller
 {
     /**
      * The init() method is called by the request object after the controller
      * is instantiated.
      * 
-     * @param Request $request
+     * @param Apify_Request $request
      * @return void
      * @throws Exception
      */
@@ -13,19 +13,19 @@ class IndexController extends Controller
     {
         if (! method_exists($this, $request->getAction().'Action')) {
             $message = sprintf('%s(): Intercepted call to "%s" action', __METHOD__, $request->getAction());
-            throw new Exception($message, Response::NOT_FOUND);
+            throw new Exception($message, Apify_Response::NOT_FOUND);
         }
     }
     
     /** 
      * @route GET /
      * 
-     * @param Request $request
+     * @param Apify_Request $request
      * @return View
      */
     public function indexAction($request)
     {
-        $view = new View();
+        $view = new Apify_View();
         $view->setLayout('main');
         
         return $view;
@@ -37,12 +37,12 @@ class IndexController extends Controller
      * @route GET /?method=example.request
      * @route GET /example/request
      * 
-     * @param Request $request
+     * @param Apify_Request $request
      * @return View
      */
     public function requestAction($request) 
     {
-        $view = new View();
+        $view = new Apify_View();
         $view->setLayout('main');
         
         $view->method = $request->getMethod();
@@ -63,15 +63,15 @@ class IndexController extends Controller
      * @route GET /example/response.json
      * @route GET /example/response.xml
      * 
-     * @param Request $request
-     * @return Response
+     * @param Apify_Request $request
+     * @return Apify_Response
      */
     public function responseAction($request) 
     {
         // accept JSON and XML
         $request->acceptContentTypes(array('json', 'xml'));
         
-        $response = new Response();
+        $response = new Apify_Response();
         $response->statusCode = $response->getCode();
         $response->contentType = $request->getContentType();
         $response->key = 'value';
@@ -85,8 +85,8 @@ class IndexController extends Controller
      * @route GET /?method=example.mixed
      * @route GET /example/mixed
      * 
-     * @param Request $request
-     * @return View|Response
+     * @param Apify_Request $request
+     * @return Apify_View|Apify_Response
      */
     public function mixedAction($request) 
     {
@@ -94,10 +94,10 @@ class IndexController extends Controller
         $request->acceptContentTypes(array('html', 'json', 'xml'));
         
         if ('html' === $request->getContentType()) {
-            $response = new View();
+            $response = new Apify_View();
             $response->setLayout('main');
         } else {
-            $response = new Response();
+            $response = new Apify_Response();
         }
         
         $response->method = $request->getMethod();

--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -1,12 +1,12 @@
 <?php
-class UsersController extends Controller
+class UsersController extends Apify_Controller
 {
     /**
      * @route GET /?method=users
      * @route GET /users
      * 
-     * @param Request $request
-     * @return Response|View
+     * @param Apify_Request $request
+     * @return Apify_Response|View
      */
     public function indexAction($request)
     {
@@ -14,10 +14,10 @@ class UsersController extends Controller
         $request->acceptContentTypes(array('html', 'json', 'xml'));
         
         if ('html' == $request->getContentType()) {
-            $response = new View();
+            $response = new Apify_View();
             $response->setLayout('main');
         } else {
-            $response = new Response();
+            $response = new Apify_Response();
         }
         
         $response->users = $this->getModel('User')->findAll();
@@ -43,14 +43,14 @@ class UsersController extends Controller
         $id = $request->getParam('id');
         $user = is_numeric($id) ? $model->find($id) : $model->findBy(array('username'=>$id));
         if (! $user) {
-            throw new Exception('User not found', Response::NOT_FOUND);
+            throw new Exception('User not found', Apify_Response::NOT_FOUND);
         }
         
         if ('html' == $request->getContentType()) {
-            $response = new View();
+            $response = new Apify_View();
             $response->setLayout('main');
         } else {
-            $response = new Response();
+            $response = new Apify_Response();
             $response->setEtagHeader(md5('/users/' . $user->id));
         }
         
@@ -62,15 +62,15 @@ class UsersController extends Controller
      * @route POST /?method=users.create&format=json
      * @route POST /users/create.json
      * 
-     * @param Request $request
-     * @return Response
+     * @param Apify_Request $request
+     * @return Apify_Response
      * @throws Exception
      */
     public function createAction($request)
     {
         $request->acceptContentTypes(array('json'));
         if ('POST' != $request->getMethod()) {
-            throw new Exception('HTTP method not allowed', Response::NOT_ALLOWED);
+            throw new Exception('HTTP method not allowed', Apify_Response::NOT_ALLOWED);
         }
         
         try {
@@ -80,17 +80,17 @@ class UsersController extends Controller
                 'email'    => $request->getPost('email'), 
                 'gender'   => $request->getPost('gender')
             ));
-        } catch (ValidationException $e) {
-            throw new Exception($e->getMessage(), Response::OK);
+        } catch (Apify_ValidationException $e) {
+            throw new Exception($e->getMessage(), Apify_Response::OK);
         }
         
         $id = $this->getModel('User')->save($user);
         if (! is_numeric($id)) {
-            throw new Exception('An error occurred while creating user', Response::OK);
+            throw new Exception('An error occurred while creating user', Apify_Response::OK);
         }
         
-        $response = new Response();
-        $response->setCode(Response::CREATED);
+        $response = new Apify_Response();
+        $response->setCode(Apify_Response::CREATED);
         $response->setEtagHeader(md5('/users/' . $id));
         
         return $response;
@@ -100,15 +100,15 @@ class UsersController extends Controller
      * @route POST /?method=users.update&id=1&format=json
      * @route POST /users/1/update.json
      * 
-     * @param Request $request
-     * @return Response
+     * @param Apify_Request $request
+     * @return Apify_Response
      * @throws Exception
      */
     public function updateAction($request)
     {
         $request->acceptContentTypes(array('json'));
         if ('POST' != $request->getMethod()) {
-            throw new Exception('HTTP method not supported', Response::NOT_ALLOWED);
+            throw new Exception('HTTP method not supported', Apify_Response::NOT_ALLOWED);
         }        
         
         $id = $request->getParam('id');
@@ -116,26 +116,26 @@ class UsersController extends Controller
         $model = $this->getModel('User');
         $user = $model->find($id);
         if (! $user) {
-            throw new Exception('User not found', Response::NOT_FOUND);
+            throw new Exception('User not found', Apify_Response::NOT_FOUND);
         }
         
         try {
             $user->username = $request->getPost('username');            
-        } catch (ValidationException $e) {
-            throw new Exception($e->getMessage(), Response::OK);
+        } catch (Apify_ValidationException $e) {
+            throw new Exception($e->getMessage(), Apify_Response::OK);
         }
         $model->save($user);
         
         // return 200 OK
-        return new Response();
+        return new Apify_Response();
     }
     
     /**
      * @route GET /?method=users.destroy&id=1&format=json
      * @route GET /users/1/destroy.json
      * 
-     * @param Request $request
-     * @return Response
+     * @param Apify_Request $request
+     * @return Apify_Response
      * @throws Exception
      */
     public function destroyAction($request)
@@ -146,11 +146,11 @@ class UsersController extends Controller
         $model = $this->getModel('User');
         $user = $model->find($id);
         if (! $user) {
-            throw new Exception('User not found', Response::NOT_FOUND);
+            throw new Exception('User not found', Apify_Response::NOT_FOUND);
         }
         $model->delete($user->id);
         
         // return 200 OK
-        return new Response();
+        return new Apify_Response();
     }
 }

--- a/app/models/Post.php
+++ b/app/models/Post.php
@@ -1,5 +1,5 @@
 <?php
-class Post extends Entity
+class Post extends Apify_Entity
 {
     protected $id;
     protected $category_id;
@@ -11,7 +11,7 @@ class Post extends Entity
     public function setCategoryId($value)
     {
         if (! is_numeric($value)) {
-            throw new ValidationException('The category you have selected is invalid');
+            throw new Apify_ValidationException('The category you have selected is invalid');
         }
         $this->category_id = (int) $value;
     }
@@ -20,7 +20,7 @@ class Post extends Entity
     {
         $value = htmlspecialchars(strip_tags($value), ENT_QUOTES);
         if (empty($value) || strlen($value) < 5) {
-            throw new ValidationException('The title is shorter than 5 characters');
+            throw new Apify_ValidationException('The title is shorter than 5 characters');
         }
         $this->title = $value;
     }
@@ -29,7 +29,7 @@ class Post extends Entity
     {
         $value = htmlspecialchars(strip_tags($value), ENT_QUOTES);
         if (empty($value) || strlen($value) < 5) {
-            throw new ValidationException('The text is shorter than 5 characters');
+            throw new Apify_ValidationException('The text is shorter than 5 characters');
         }        
         $this->text = $value;
     }    

--- a/app/models/PostModel.php
+++ b/app/models/PostModel.php
@@ -1,5 +1,5 @@
 <?php
-class PostModel extends Model
+class PostModel extends Apify_Model
 {
     /**
      * By default, the entity will be persisted to a table with the same name 
@@ -18,7 +18,7 @@ class PostModel extends Model
      * @param string $foo
      * @param string $bar
      * @returns false|obj
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function findByFooOrBar($foo, $bar)
     {
@@ -29,7 +29,7 @@ class PostModel extends Model
             $stmt = $this->execute($sql, array($foo, $bar));
             return $stmt->fetch();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
     
@@ -40,7 +40,7 @@ class PostModel extends Model
      * @param int $categoryId
      * @param array $options sort, order, page and count
      * @returns false|array
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function findAllByCategoryId($categoryId, $options)
     {        
@@ -66,7 +66,7 @@ class PostModel extends Model
             $stmt = $this->execute($sql, array($categoryId));
             return $stmt->fetchAll();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
 }

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -1,5 +1,5 @@
 <?php
-class User extends Entity
+class User extends Apify_Entity
 {
     protected $id;
     protected $email;
@@ -14,7 +14,7 @@ class User extends Entity
     public function setUsername($value)
     {
         if (preg_match('/[^a-z0-9\-_.]/i', $value)) { // Undefined variable error fixed
-            throw new ValidationException('Invalid username');
+            throw new Apify_ValidationException('Invalid username');
         }
         $this->username = $value;
     }
@@ -24,7 +24,7 @@ class User extends Entity
     {
         $value = htmlspecialchars(trim($value), ENT_QUOTES);
         if (empty($value) || strlen($value) < 3) {
-            throw new ValidationException('Invalid name');
+            throw new Apify_ValidationException('Invalid name');
         }
         $this->name = $value;
     }
@@ -33,7 +33,7 @@ class User extends Entity
     public function setEmail($value)
     {
         if (! filter_var($value, FILTER_VALIDATE_EMAIL)) {
-            throw new ValidationException('Invalid email address');
+            throw new Apify_ValidationException('Invalid email address');
         }
         $this->email = $value;
     }

--- a/app/views/error/development.phtml
+++ b/app/views/error/development.phtml
@@ -16,7 +16,7 @@
 
 <h3>Queries</h3>
 <div class="info">
-	<pre><?php try { var_dump(Loader::getInstance()->getDatabase()->getQueries()); } catch (Exception $e) { echo 'Not connected'; } ?></pre>
+	<pre><?php try { var_dump(Apify_Loader::getInstance()->getDatabase()->getQueries()); } catch (Exception $e) { echo 'Not connected'; } ?></pre>
 </div>
 
 <br/>

--- a/config/config.php
+++ b/config/config.php
@@ -13,7 +13,7 @@ if (DEBUG) {
 define('DB_HOST', 'localhost');
 define('DB_NAME', 'apify');
 define('DB_USER', 'root');
-define('DB_PASS', 'root');
+define('DB_PASS', '');
 
 // Default timezone used by all date/time functions
 date_default_timezone_set('Europe/London');
@@ -28,16 +28,17 @@ if (get_magic_quotes_runtime()) {
 }
 
 // Required files
-require_once ROOT_DIR . '/library/Exceptions.php';
-require_once ROOT_DIR . '/library/Loader.php';
-require_once ROOT_DIR . '/library/Model.php';
-require_once ROOT_DIR . '/library/Router.php';
-// ZF base controller (optional)
-require_once APP_DIR . '/controllers/Controller.php';
+require_once ROOT_DIR . '/library/Apify/Exceptions.php';
+require_once ROOT_DIR . '/library/Apify/Loader.php';
 
 // Include path
-set_include_path(ROOT_DIR . '/library' . PATH_SEPARATOR . APP_DIR . '/models');
-spl_autoload_register(array('Loader', 'autoload'));
+$includePath = get_include_path();
+$includePath .= PATH_SEPARATOR . ROOT_DIR . DIRECTORY_SEPARATOR . 'library' . DIRECTORY_SEPARATOR;
+$includePath .= PATH_SEPARATOR . APP_DIR . DIRECTORY_SEPARATOR . 'models' . DIRECTORY_SEPARATOR;
+$includePath .= PATH_SEPARATOR . APP_DIR . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR;
+set_include_path($includePath);
+
+spl_autoload_register(array('Apify_Loader', 'autoload'));
 
 
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,25 +1,25 @@
 <?php
-$routes[] = new Route('/', 
+$routes[] = new Apify_Route('/', 
     array(
         'controller' => 'index', 
         'action'     => 'index'
     )
 );
 
-$routes[] = new Route('/example/:action', 
+$routes[] = new Apify_Route('/example/:action', 
     array(
         'controller' => 'index'
     )
 );
 
-$routes[] = new Route('/users/:id', 
+$routes[] = new Apify_Route('/users/:id', 
     array(
         'controller' => 'users',
         'action'     => 'show'
     )
 );
 
-$routes[] = new Route('/users/:id/:action', 
+$routes[] = new Apify_Route('/users/:id/:action', 
     array(
         'controller' => 'users'
     ),
@@ -29,14 +29,14 @@ $routes[] = new Route('/users/:id/:action',
     )
 );
 
-$routes[] = new Route('/users/create', 
+$routes[] = new Apify_Route('/users/create', 
     array(
         'controller' => 'users',
         'action'     => 'create'
     )
 );
 
-$routes[] = new Route('/users', 
+$routes[] = new Apify_Route('/users', 
     array(
         'controller' => 'users',
         'action'     => 'index'

--- a/doc/Controller.md
+++ b/doc/Controller.md
@@ -14,7 +14,7 @@ The full request object is injected via the action method and is primarily used 
 
 ### Controller
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         /**
          * GET /users/1.json
@@ -25,7 +25,7 @@ The full request object is injected via the action method and is primarily used 
         	// only accept JSON and XML
             $request->acceptContentTypes(array('json', 'xml'));
 
-            $response = new Response();        
+            $response = new Apify_Response();        
             $response->id = $request->getParam('id');
             $response->api_key = $request->getParam('api_key');
             
@@ -35,7 +35,7 @@ The full request object is injected via the action method and is primarily used 
 
 You can customize instantiation using the init() method, which is called by the request object before calling the action method:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function init($request)
         {
@@ -52,7 +52,7 @@ You can customize instantiation using the init() method, which is called by the 
 
         public function showAction($request)
         {
-            $response = new Response();        
+            $response = new Apify_Response();        
             $response->id = $request->getParam('id');
             $response->api_key = $request->getParam('api_key');
             
@@ -66,13 +66,13 @@ When Apify returns error messages, it does so in your requested format.
 
 An error from a JSON request might look like this:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request)
         {
             $request->acceptContentTypes(array('json', 'xml'));
 
-            $response = new Response();
+            $response = new Apify_Response();
             if (! $request->hasParam('api_key')) {
                 throw new Exception('Missing parameter: api_key', Response::FORBIDDEN);
             }

--- a/doc/Model.md
+++ b/doc/Model.md
@@ -6,7 +6,7 @@ The model has a central position in a web application. It’s the domain-specifi
 
 An Entity instance represents a row in the database. In the example below, "User" is an entity class which maps object properties to database table fields. For example:
 
-    class User extends Entity 
+    class User extends Apify_Entity 
     {
         protected $id;
         protected $username;
@@ -24,7 +24,7 @@ Properties are defined as protected. If you add a "created_at" or "updated_at" p
 
 You can define the getter and setter methods yourself. If a method exists Apify will use the existing accessors.
 
-    class User extends Entity 
+    class User extends Apify_Entity 
     {
         protected $id;
         protected $email;
@@ -37,7 +37,7 @@ You can define the getter and setter methods yourself. If a method exists Apify 
 
 By default, the entity will be persisted to a table with the same name as the class name ("user"). In order to change that, you can call the setTable() method:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function showAction($request)
         {
@@ -46,7 +46,7 @@ By default, the entity will be persisted to a table with the same name as the cl
             // map the entity "User" to the table "users"
             $model = $this->getModel('User')->setTable('users');
             
-            $response = new Response();
+            $response = new Apify_Response();
             $response->user = $model->find($id);
             
             return $response;
@@ -55,7 +55,7 @@ By default, the entity will be persisted to a table with the same name as the cl
 
 Or you can create a Model class and overwrite the $table property as follows:
 
-    class UserModel extends Model
+    class UserModel extends Apify_Model
     {
         // user-defined table
         protected $table = 'users';
@@ -67,13 +67,13 @@ Or you can create a Model class and overwrite the $table property as follows:
         }
     }
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function showAction($request)
         {
             $username = $request->getParam('username');
 
-            $response = new Response();
+            $response = new Apify_Response();
             $response->user = $this->getModel('User')->findByUsername($username);
             
             return $response;
@@ -84,7 +84,7 @@ Or you can create a Model class and overwrite the $table property as follows:
 
 Validating data before you send updates to the underlying database is a good practice that reduces errors:
 
-    class User extends Entity 
+    class User extends Apify_Entity 
     {
         protected $id;
         protected $email;
@@ -93,7 +93,7 @@ Validating data before you send updates to the underlying database is a good pra
         public function setEmail($value)
         {
             if (! filter_var($value, FILTER_VALIDATE_EMAIL)) {
-                throw new ValidationException('Invalid email address');
+                throw new Apify_ValidationException('Invalid email address');
             }
             $this->email = trim($value);
         }
@@ -101,7 +101,7 @@ Validating data before you send updates to the underlying database is a good pra
 
 Because the validation is performed inside the class an exception is thrown if the value causes validation to fail. You can implement error handling for the code in your controller:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {    
         public function updateAction($request)
         {
@@ -118,11 +118,11 @@ Because the validation is performed inside the class an exception is thrown if t
             }
             
             try {
-                $user->email = $request->getPost('email'); // throws ValidationException
-                $model->save($user); // throws ModelException
-            } catch (ValidationException $e) {
+                $user->email = $request->getPost('email'); // throws Apify_ValidationException
+                $model->save($user); // throws Apify_ModelException
+            } catch (Apify_ValidationException $e) {
                 // do something
-            } catch (ModelException $e) {
+            } catch (Apify_ModelException $e) {
                 // do something
             }
             

--- a/doc/Request.md
+++ b/doc/Request.md
@@ -19,14 +19,14 @@ Clean URL scheme:
 
 To implement a clean URL scheme you need to enable URL rewriting and add at least one route:
 
-    $routes[] = new Route('/users/:id', 
+    $routes[] = new Apify_Route('/users/:id', 
         array(
             'controller' => 'users',
             'action'     => 'show'
         )
     );
 
-    $routes[] = new Route('/users/:id/:action', 
+    $routes[] = new Apify_Route('/users/:id/:action', 
         array(
             'controller' => 'users'
         ),
@@ -36,7 +36,7 @@ To implement a clean URL scheme you need to enable URL rewriting and add at leas
         )
     );
 
-    $request = new Request();
+    $request = new Apify_Request();
     $request->enableUrlRewriting();
     $request->addRoutes($routes);
     $request->dispatch();
@@ -59,7 +59,7 @@ Clean URL scheme:
 
 To enable this functionality:
 
-    $request = new Request();
+    $request = new Apify_Request();
     $request->enableUrlRewriting();
     $request->enableRestfulMapping();
     $request->dispatch();
@@ -103,7 +103,7 @@ And, in your index.php file:
     define('APP_DIR',  dirname(__FILE__) . '/' . $_SERVER['APP_NAME']);
         
     try {
-        $request = new Request();
+        $request = new Apify_Request();
         $request->setUrlSegment($_SERVER['URL_SEGMENT']);
         $request->enableUrlRewriting();
         $request->dispatch();
@@ -142,20 +142,20 @@ If RESTful Mapping is enabled, send a standard Accept header in your request (te
 ### Acceptable Formats
 Action methods can use the $request->acceptContentTypes() method to specify certain media types which are acceptable for the response.
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         /** 
          * Route /users.json
          * Route /users.xml
          *
-         * @param Request $request
-         * @return Response
+         * @param Apify_Request $request
+         * @return Apify_Response
          */
         public function indexAction($request)
         {
             $request->acceptContentTypes(array('json', 'xml'));
 
-            $response = new Response();
+            $response = new Apify_Response();
             $response->users = array('paul', 'adrian', 'adam');
 
             return $response;
@@ -164,7 +164,7 @@ Action methods can use the $request->acceptContentTypes() method to specify cert
 
 You can also make JSON the default format:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         /** 
          * Route /users
@@ -177,7 +177,7 @@ You can also make JSON the default format:
         {
             $request->setContentType('json');
 
-            $response = new Response();
+            $response = new Apify_Response();
             $response->users = array('paul', 'adrian', 'adam');
 
             return $response;

--- a/doc/Response.md
+++ b/doc/Response.md
@@ -8,22 +8,22 @@ In Apify, Controllers handle incoming HTTP requests, interact with the model to 
 
 Creating a RESTful web API with Apify is easy. Each action results in a response, which holds the headers and document to be sent to the user’s browser. You are responsible for generating the response object inside the action method.
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request)
         {
             // 200 OK
-            return new Response();
+            return new Apify_Response();
         }
     }
 
 The response object describes the status code and any headers that are sent. The default response is always 200 OK, however, it is possible to overwrite the default status code and add additional headers:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request)
         {
-            $response = new Response();
+            $response = new Apify_Response();
 
             // 401 Unauthorized
             $response->setCode(Response::UNAUTHORIZED);
@@ -55,26 +55,26 @@ Specifying the response format in the query string. This means a format=xml or f
 Sending a standard Accept header in your request (text/html, application/xml or application/json).
 The acceptContentTypes() method indicates that the request only accepts certain content types:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request)
         {
         	// only accept JSON and XML
             $request->acceptContentTypes(array('json', 'xml'));
 
-            return new Response();
+            return new Apify_Response();
         }
     }
 
 Apify will render the error message according to the format of the request.
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request)
         {
             $request->acceptContentTypes(array('json', 'xml'));
 
-        	$response = new Response();
+        	$response = new Apify_Response();
             if (! $request->hasParam('api_key')) {
                 throw new Exception('Missing parameter: api_key', Response::FORBIDDEN);
             }
@@ -153,7 +153,7 @@ DELETE, to different actions in a controller. This basic REST design principle e
 If you wish to enable RESTful mappings, add the following line to the index.php file:
 
     try {
-        $request = new Request();
+        $request = new Apify_Request();
         $request->enableUrlRewriting();
         $request->enableRestfulMapping();
         $request->dispatch();
@@ -163,7 +163,7 @@ If you wish to enable RESTful mappings, add the following line to the index.php 
 
 The RESTful UsersController for the above mapping will contain 5 actions as follows:
 
-    class UsersController extends Controller
+    class UsersController extends Apify_Controller
     {
         public function indexAction($request) {}
         public function showAction($request) {}

--- a/doc/View.md
+++ b/doc/View.md
@@ -6,13 +6,13 @@ Apify supports routing arbitrary URLs to actions allowing you to quickly build w
 
 Building a web application can be as simple as adding a few methods to your controller:
 
-    class PostsController extends Controller
+    class PostsController extends Apify_Controller
     {
         /** 
          * Route /posts/:id
          *
-         * @param Request $request
-         * @return View
+         * @param Apify_Request $request
+         * @return Apify_View
          */
         public function showAction($request)
         {
@@ -33,7 +33,7 @@ Building a web application can be as simple as adding a few methods to your cont
          * Route /posts/create
          *
          * @param Request $request
-         * @return View|null
+         * @return Apify_View|null
          */
         public function createAction($request)
         {
@@ -47,7 +47,7 @@ Building a web application can be as simple as adding a few methods to your cont
                     'title' => $request->getPost('title'), 
                     'text'  => $request->getPost('text')
                 ));            
-            } catch (ValidationException $e) {
+            } catch (Apify_ValidationException $e) {
                 $view->error = $e->getMessage();
                 return $view;
             }
@@ -61,7 +61,7 @@ Building a web application can be as simple as adding a few methods to your cont
 
 You can add validation to your entity class to ensure that the values sent by the user are correct before saving them to the database:
 
-    class Post extends Entity
+    class Post extends Apify_Entity
     {
         protected $id;
         protected $title;
@@ -72,7 +72,7 @@ You can add validation to your entity class to ensure that the values sent by th
         {
             $value = htmlspecialchars(trim($value), ENT_QUOTES);
             if (empty($value) || strlen($value) < 3) {
-                throw new ValidationException('Invalid title');
+                throw new Apify_ValidationException('Invalid title');
             }
             $this->title = $title;
         }
@@ -88,7 +88,7 @@ You can add validation to your entity class to ensure that the values sent by th
 
 Apify provides a slimmed down version of the Zend Framework router:
 
-    $routes[] = new Route('/posts/:id', 
+    $routes[] = new Apify_Route('/posts/:id', 
         array(
             'controller' => 'posts',
             'action'     => 'show'
@@ -97,7 +97,7 @@ Apify provides a slimmed down version of the Zend Framework router:
             'id'         => '\d+'
         )
     );
-    $routes[] = new Route('/posts/create', 
+    $routes[] = new Apify_Route('/posts/create', 
         array(
             'controller' => 'posts', 
             'action'     => 'create'

--- a/library/Apify/Controller.php
+++ b/library/Apify/Controller.php
@@ -10,15 +10,15 @@
  *
  * Subclassing Controller is optional. 
  */
-abstract class Controller
+abstract class Apify_Controller
 {
     /**
-     * @var null|View
+     * @var null|Apify_View
      */
     protected $view;
     
     /**
-     * @var null|Request
+     * @var null|Apify_Request
      */
     protected $request;
         
@@ -27,7 +27,7 @@ abstract class Controller
      * 
      * Initialize object. Method called by the Request object.
      *
-     * @param Request $request
+     * @param Apify_Request $request
      * @return void
      */
     public function init($request) 
@@ -38,7 +38,7 @@ abstract class Controller
      * 
      * Sets the Request object
      *
-     * @param Request $request
+     * @param Apify_Request $request
      * @return self
      */
     public function setRequest($request)
@@ -52,7 +52,7 @@ abstract class Controller
      * 
      * Returns the Request object
      *
-     * @return Request
+     * @return Apify_Request
      */
     public function getRequest()
     {
@@ -129,7 +129,7 @@ abstract class Controller
      * @param array $options Options to be used when redirecting
      * @return void
      */
-    protected function _redirect($uri, $code = Response::FOUND)
+    protected function _redirect($uri, $code = Apify_Response::FOUND)
     {
         $this->getRequest()->redirect($uri, $code);
     }
@@ -143,14 +143,14 @@ abstract class Controller
      */
     public function initView()
     {
-        $this->view = new View();
+        $this->view = new Apify_View();
         return $this->view;
     }
     
     /**
      * @param View $view
      */
-    public function setView(View $view)
+    public function setView(Apify_View $view)
     {
         $this->view = $view;
     }
@@ -158,7 +158,7 @@ abstract class Controller
     /**
      * Returns an single instance of the View object.
      * 
-     * @return null|View 
+     * @return null|Apify_View 
      */
     public function getView()
     {
@@ -186,6 +186,6 @@ abstract class Controller
      */
     public function getModel($name) 
     {
-        return Loader::getInstance()->getModel($name);
+        return Apify_Loader::getInstance()->getModel($name);
     }
 }

--- a/library/Apify/Database.php
+++ b/library/Apify/Database.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Database
+class Apify_Database
 {
     /**
      * @var $pdo PDO 

--- a/library/Apify/Exceptions.php
+++ b/library/Apify/Exceptions.php
@@ -20,11 +20,11 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class LoaderException extends Exception {}
-class RequestException extends Exception {}
-class ResponseException extends Exception {}
-class RendererException extends Exception {}
-class ControllerException extends Exception {}
-class ModelException extends Exception {}
-class EntityException extends Exception {}
-class ValidationException extends Exception {}
+class Apify_LoaderException extends Exception {}
+class Apify_RequestException extends Exception {}
+class Apify_ResponseException extends Exception {}
+class Apify_RendererException extends Exception {}
+class Apify_ControllerException extends Exception {}
+class Apify_ModelException extends Exception {}
+class Apify_EntityException extends Exception {}
+class Apify_ValidationException extends Exception {}

--- a/library/Apify/Loader.php
+++ b/library/Apify/Loader.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Loader
+class Apify_Loader
 {
     /**
      * @var array $registry
@@ -28,12 +28,12 @@ class Loader
     private $registry = array();
 
     /**
-     * @var Loader Singleton instance
+     * @var Apify_Loader Singleton instance
      */
     private static $instance = null;
     
     /**
-     * @return Loader
+     * @return Apify_Loader
      */
     public static function getInstance()
     {
@@ -83,7 +83,7 @@ class Loader
     /**
      * @param string $name Controller name
      * @return object|null
-     * @throws LoaderException
+     * @throws Apify_LoaderException
      */
     public function getController($name)
     {
@@ -91,7 +91,7 @@ class Loader
         if (! $this->isRegistered($className)) {
             if (! $this->includeFile($className, 'controllers')) {
                 $m = sprintf('Controller "%s" not found', $name);
-                throw new LoaderException($m, Response::NOT_FOUND);
+                throw new Apify_LoaderException($m, Apify_Response::NOT_FOUND);
             }
             $this->add(new $className());
         }
@@ -100,7 +100,7 @@ class Loader
 
     /**
      * @param string $entityName
-     * @return Model
+     * @return Apify_Model
      */
     public function getModel($entityName)
     {
@@ -109,14 +109,14 @@ class Loader
             if ($this->includeFile($modelName, 'models')) {
                 $model = new $modelName($this->getDatabase());
             } else {
-                $model = new Model($this->getDatabase());
+                $model = new Apify_Model($this->getDatabase());
             }
             
             $this->includeFile($entityName, 'models');
             $model->setEntity($entityName);
             
             if (null === $model->getTable()) {
-                $tableName = $this->get('StringUtil')->underscore($entityName);
+                $tableName = $this->get('Apify_StringUtil')->underscore($entityName);
                 $model->setTable($tableName);
             } 
             
@@ -128,7 +128,7 @@ class Loader
     /**
      * @param string $name Service name
      * @return Service
-     * @throws LoaderException
+     * @throws Apify_LoaderException
      */
     public function getService($name)
     {
@@ -136,7 +136,7 @@ class Loader
         if (! $this->isRegistered($className)) {
             if (! $this->includeFile($className, 'services')) {
                 $m = sprintf('Service "%s" not found', $name);
-                throw new LoaderException($m, Response::NOT_FOUND);
+                throw new Apify_LoaderException($m, Apify_Response::NOT_FOUND);
             } else {
                 $obj = new $className();
             }
@@ -146,20 +146,20 @@ class Loader
     }
     
     /**
-     * @return Database
-     * @throws LoaderException
+     * @return Apify_Database
+     * @throws Apify_LoaderException
      */
     public function getDatabase()
     {
-        if (! $this->isRegistered('Database')) {
+        if (! $this->isRegistered('Apify_Database')) {
             try {
-                $obj = new Database(DB_HOST, DB_NAME, DB_USER, DB_PASS);
+                $obj = new Apify_Database(DB_HOST, DB_NAME, DB_USER, DB_PASS);
             } catch (Exception $e) {
-                throw new LoaderException($e->getMessage());
+                throw new Apify_LoaderException($e->getMessage());
             }
             $this->add($obj);
         }
-        return $this->get('Database');
+        return $this->get('Apify_Database');
     }
         
     /**

--- a/library/Apify/Model.php
+++ b/library/Apify/Model.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Model
+class Apify_Model
 {
     /**
      * @var Database
@@ -50,9 +50,9 @@ class Model
     /**
      * Class constructor.
      * 
-     * @param Database $db
+     * @param Apify_Database $db
      */
-    public function __construct(Database $db)
+    public function __construct(Apify_Database $db)
     {
         $this->db = $db;
     }
@@ -61,7 +61,7 @@ class Model
      * Sets default option values.
      *
      * @param array $options
-     * @return Model 
+     * @return Apify_Model 
      */
     public function setDefaultOptions(array $options)
     {
@@ -88,7 +88,7 @@ class Model
      * Sets the table name.
      * 
      * @param string $name
-     * @return Model
+     * @return Apify_Model
      */
     public function setTable($name)
     {
@@ -108,7 +108,7 @@ class Model
      * Sets the entity class name.
      * 
      * @param string $name
-     * @return Model
+     * @return Apify_Model
      */
     public function setEntity($name)
     {
@@ -151,7 +151,7 @@ class Model
     /**
      * @param int $id
      * @return object|false
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function find($id)
     {
@@ -162,14 +162,14 @@ class Model
             $stmt->setFetchMode(PDO::FETCH_CLASS|PDO::FETCH_PROPS_LATE, $this->entity);
             return $stmt->fetch();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
     
     /**
      * @param array $condition
      * @return object|false
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function findBy(array $condition)
     {
@@ -188,14 +188,14 @@ class Model
             $stmt->setFetchMode(PDO::FETCH_CLASS|PDO::FETCH_PROPS_LATE, $this->entity);
             return $stmt->fetch();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
     
     /**
      * @param array $options
      * @return array|false
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function findAll(array $options = array())
     {
@@ -208,7 +208,7 @@ class Model
             $stmt = $this->execute($sql, array($options['sort'], $options['order']));
             return $stmt->fetchAll();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         } 
     }
     
@@ -216,7 +216,7 @@ class Model
      * @param array $condition
      * @param array $options
      * @return object|false
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function findAllBy(array $condition, array $options = array())
     {
@@ -238,16 +238,16 @@ class Model
             $stmt = $this->execute($sql, $values);
             return $stmt->fetchAll();
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         } 
     }
     
     /**
-     * @param Entity $entity
+     * @param Apify_Entity $entity
      * @return mixed
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
-    public function save(Entity $entity)
+    public function save(Apify_Entity $entity)
     {
         try {
             if (null === $entity->id) {
@@ -256,15 +256,15 @@ class Model
                 return $this->update($entity);
             }
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
     
     /**
-     * @param Entity $entity
+     * @param Apify_Entity $entity
      * @return int Returns the ID of the last inserted row
      */
-    public function insert(Entity $entity)
+    public function insert(Apify_Entity $entity)
     {
         $vars = $entity->toArray();
         unset($vars['id']);
@@ -295,10 +295,10 @@ class Model
     }
         
     /**
-     * @param Entity $entity
+     * @param Apify_Entity $entity
      * @return int Returns the number of rows affected by the query 
      */
-    public function update(Entity $entity)
+    public function update(Apify_Entity $entity)
     {
         $vars = $entity->toArray();
         unset($vars['id'], $vars['created_at']);
@@ -341,7 +341,7 @@ class Model
         try {
             $stmt = $this->execute($sql, array((int)$id));
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
         
         return ($stmt instanceof PDOStatement) ? $stmt->rowCount() : false;
@@ -351,7 +351,7 @@ class Model
      * Returns the total number of rows in the last executed query.
      *
      * @return int
-     * @throws ModelException
+     * @throws Apify_ModelException
      */
     public function getTotalRows()
     {
@@ -365,7 +365,7 @@ class Model
             }
             return $rowsCount;
         } catch (Exception $e) {
-            throw new ModelException($e->getMessage());
+            throw new Apify_ModelException($e->getMessage());
         }
     }
     
@@ -486,7 +486,7 @@ class Model
 /**
  * Base entity class
  */
-class Entity
+class Apify_Entity
 {
     private static $updated = array();
     
@@ -515,9 +515,9 @@ class Entity
     protected function setProperty($name, $value) 
     {
         if (! is_string($name)) {
-            throw new EntityException('Invalid property name: '. $name);
+            throw new Apify_EntityException('Invalid property name: '. $name);
         } else if (! property_exists($this, $name)) {
-            throw new EntityException('Property not defined: ' . $name);
+            throw new Apify_EntityException('Property not defined: ' . $name);
         }
         
         $setterMethod = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $name)));

--- a/library/Apify/Renderer.php
+++ b/library/Apify/Renderer.php
@@ -20,29 +20,29 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Renderer
+class Apify_Renderer
 {
     /**
-     * @param Request $request
+     * @param Apify_Request $request
      * @return void
      * @throws RendererException
      */
-    public function render(Request $request)
+    public function render(Apify_Request $request)
     {
         $response = $request->getResponse();
         
         $contentType = $request->getContentType();
         if ('json' === $contentType) {
-            $renderer = new JsonRenderer();
+            $renderer = new Apify_JsonRenderer();
         } else if ('xml' === $contentType) {
-            $renderer = new XmlRenderer();
+            $renderer = new Apify_XmlRenderer();
         } else if ('rss' === $contentType) {
-            $renderer = new RssRenderer();
+            $renderer = new Apify_RssRenderer();
         } else if ('html' === $contentType) {
-            $renderer = new HtmlRenderer();
+            $renderer = new Apify_HtmlRenderer();
         } else {
-            $renderer = new HtmlRenderer();
-            $e = new RendererException('Content type missing or invalid', Response::NOT_FOUND);
+            $renderer = new Apify_HtmlRenderer();
+            $e = new Apify_RendererException('Content type missing or invalid', Apify_Response::NOT_FOUND);
             $response->setException($e);     
         }
         
@@ -53,18 +53,18 @@ class Renderer
     }
 }
 
-class HtmlRenderer
+class Apify_HtmlRenderer
 {
     /**
-     * @param Request $request
-     * @param Response $response
+     * @param Apify_Request $request
+     * @param Apify_Response $response
      * @return string
      * @throws RuntimeException
      */
-    public function render(Request $request, Response $response)
+    public function render(Apify_Request $request, Apify_Response $response)
     {
         $view = $response->getView(); 
-        if (! ($view instanceof View))  {
+        if (! ($view instanceof Apify_View))  {
             throw new RuntimeException('No View object set; unable to render view');
         }
         
@@ -106,14 +106,14 @@ class HtmlRenderer
     }
 }
 
-class JsonRenderer
+class Apify_JsonRenderer
 {
     /**
-     * @param Request $request
-     * @param Response $response
+     * @param Apify_Request $request
+     * @param Apify_Response $response
      * @return string
      */
-    public function render(Request $request, Response $response)
+    public function render(Apify_Request $request, Apify_Response $response)
     {
         $body = json_encode($response->toArray());
         $callback = $request->getParam('jsonCallback', null);
@@ -129,14 +129,14 @@ class JsonRenderer
     }
 }
 
-class XmlRenderer
+class Apify_XmlRenderer
 {
     /**
-     * @param Request $request
-     * @param Response $response
+     * @param Apify_Request $request
+     * @param Apify_Response $response
      * @return string
      */
-    public function render(Request $request, Response $response)
+    public function render(Apify_Request $request, Apify_Response $response)
     {
         $response->setContentTypeHeader('xml');
         $data = $response->toArray();
@@ -183,14 +183,14 @@ class XmlRenderer
     }
 }
 
-class RssRenderer extends XmlRenderer
+class Apify_RssRenderer extends Apify_XmlRenderer
 {
     /**
-     * @param Request $request
-     * @param Response $response
+     * @param Apify_Request $request
+     * @param Apify_Response $response
      * @return string
      */
-    public function render(Request $request, Response $response)
+    public function render(Apify_Request $request, Apify_Response $response)
     {
         $response->setContentTypeHeader('rss');
         $data = $response->toArray();

--- a/library/Apify/Request.php
+++ b/library/Apify/Request.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Request
+class Apify_Request
 {
     const CONTROLLER_INDEX  = 'Index';
     
@@ -46,7 +46,7 @@ class Request
     protected $isRestfulMappingEnabled = false;
         
     /**
-     * @var null|Router
+     * @var null|Apify_Router
      */
     protected $router;
     
@@ -110,7 +110,7 @@ class Request
     
     /**
      * @params string $keyword
-     * @return Request
+     * @return Apify_Request
      */
     public function setUrlKeyword($keyword)
     {
@@ -120,7 +120,7 @@ class Request
     
     /**
      * @params int $segment
-     * @return Request
+     * @return Apify_Request
      */
     public function setUrlSegment($segment)
     {
@@ -131,7 +131,7 @@ class Request
     }
     
     /**
-     * @return Request
+     * @return Apify_Request
      */
     public function enableRestfulMapping()
     {
@@ -140,7 +140,7 @@ class Request
     }
     
     /**
-     * @return Request
+     * @return Apify_Request
      */
     public function enableUrlRewriting()
     {
@@ -150,19 +150,19 @@ class Request
     
     /**
      * @param array $routes
-     * @return Request
+     * @return Apify_Request
      */
     public function addRoutes(array $routes)
     {
-        if (! ($this->router instanceof Router)) {
-            $this->router = new Router($this->getParams());
+        if (! ($this->router instanceof Apify_Router)) {
+            $this->router = new Apify_Router($this->getParams());
         }
         $this->router->addRoutes($routes);
         return $this;
     }
     
     /**
-     * @return Router
+     * @return Apify_Router
      */
     public function getRouter()
     {
@@ -175,7 +175,7 @@ class Request
     public function setController($name)
     {
         if (null !== $name && '' !== $name) {
-            $strUtil = Loader::getInstance()->get('StringUtil');
+            $strUtil = Apify_Loader::getInstance()->get('Apify_StringUtil');
             $this->controller = $strUtil->camelize($name);
         }
     }
@@ -194,7 +194,7 @@ class Request
     public function setAction($name)
     {
         if (null !== $name && '' !== $name) {
-            $strUtil = Loader::getInstance()->get('StringUtil');
+            $strUtil = Apify_Loader::getInstance()->get('Apify_StringUtil');
             $name = $strUtil->camelize($name);
             $name{0} = strtolower($name{0});
             $this->action = $name;
@@ -217,7 +217,7 @@ class Request
      */
     public function dispatch($controllerName = null, $actionName = null)
     {
-        if ($this->isUrlRewritingEnabled && $this->router instanceof Router) {
+        if ($this->isUrlRewritingEnabled && $this->router instanceof Apify_Router) {
             $this->getRouter()->route($this);
         } else if ($this->isUrlRewritingEnabled) {
             $this->parseUrl();
@@ -231,7 +231,7 @@ class Request
         $response = $this->handleRequest($controllerName, $actionName);
         $this->setResponse($response);
         
-        $renderer = new Renderer();
+        $renderer = new Apify_Renderer();
         $renderer->render($this);
     }
     
@@ -245,15 +245,15 @@ class Request
      * @param string $controllerName
      * @param string $actionName 
      * @return mixed
-     * @throws RequestException
+     * @throws Apify_RequestException
      * @throws RuntimeException
      */
     public function handleRequest($controllerName, $actionName)
     {    
         try {
-            $controller = Loader::getInstance()->getController($controllerName);
-        } catch (LoaderException $e) {
-            throw new RequestException($e->getMessage(), Response::NOT_FOUND);
+            $controller = Apify_Loader::getInstance()->getController($controllerName);
+        } catch (Apify_LoaderException $e) {
+            throw new Apify_RequestException($e->getMessage(), Apify_Response::NOT_FOUND);
         }
         
         if (method_exists($controller, 'setRequest')) {
@@ -268,7 +268,7 @@ class Request
         if (! isset($controllerResponse)) {
             if (! method_exists($controller, $actionName . 'Action')) {
                 $m = sprintf('Method "%s" not found', $actionName);
-                throw new RequestException($m, Response::NOT_FOUND);
+                throw new Apify_RequestException($m, Apify_Response::NOT_FOUND);
             }
             $controllerResponse = $controller->{$actionName . 'Action'}($this);
         }
@@ -276,12 +276,12 @@ class Request
         $this->setController($controllerName);
         $this->setAction($actionName);
         
-        if ($controllerResponse instanceof View) {
+        if ($controllerResponse instanceof Apify_View) {
             $this->setContentType('html');
-            $response = new Response();
+            $response = new Apify_Response();
             $response->setView($controllerResponse);
             return $response;      
-        } else if ($controllerResponse instanceof Response) {
+        } else if ($controllerResponse instanceof Apify_Response) {
             return $controllerResponse;
         } else {        
             $m = sprintf('Method "%s::%sAction()" contains an invalid return type', $controllerName, $actionName);
@@ -301,7 +301,7 @@ class Request
             throw $e;
         }
         
-        $response = new Response();
+        $response = new Apify_Response();
         $response->setException($e);
         $this->setResponse($response);
         
@@ -341,7 +341,7 @@ class Request
             $this->setParam('id', $parts[1]);
             $action = $methods[$method];
         } else {
-            throw new RequestException('Method not allowed', Response::NOT_ALLOWED);
+            throw new Apify_RequestException('Method not allowed', Apify_Response::NOT_ALLOWED);
         }
         
         $params = array_slice($parts, $offset);
@@ -359,7 +359,7 @@ class Request
     
     /**
      * @return void
-     * @throws RequestException
+     * @throws Apify_RequestException
      */
     public function parseQueryString()
     {
@@ -383,7 +383,7 @@ class Request
             } else if ($this->hasParam('id') && isset($methods[$method])) {
                 $action = $methods[$method];
             } else {
-                throw new RequestException('Method not allowed', Response::NOT_ALLOWED);
+                throw new Apify_RequestException('Method not allowed', Apify_Response::NOT_ALLOWED);
             }
         }
         
@@ -414,7 +414,7 @@ class Request
      * 
      * @return array
      * @throws RuntimeException
-     * @throws RequestException
+     * @throws Apify_RequestException
      */
     public function getUrlParts()
     {
@@ -554,7 +554,7 @@ class Request
     /**
      * @param string $key
      * @param mixed $value
-     * @return Request
+     * @return Apify_Request
      */
     public function setParam($key, $value)
     {
@@ -573,7 +573,7 @@ class Request
 
     /**
      * @param array $params
-     * @return Request
+     * @return Apify_Request
      */
     public function setParams(array $params)
     {
@@ -591,7 +591,7 @@ class Request
     
     /**
      * @param array $params
-     * @return Request
+     * @return Apify_Request
      */
     public function setPost(array $params)
     {
@@ -631,7 +631,7 @@ class Request
         
     /**
      * @param string $type
-     * @return Request
+     * @return Apify_Request
      */
     public function setContentType($type)
     {
@@ -660,13 +660,13 @@ class Request
      * 
      * @param array $types
      * @return void
-     * @throws RequestException
+     * @throws Apify_RequestException
      */
     public function acceptContentTypes(array $types)
     {
         if (! in_array($this->getContentType(), $types)) {
             $this->setContentType('html');
-            throw new RequestException('Not Acceptable', Response::NOT_ACCEPTABLE);   
+            throw new Apify_RequestException('Not Acceptable', Apify_Response::NOT_ACCEPTABLE);   
         }
     }
     
@@ -678,7 +678,7 @@ class Request
         $accept = explode(',', $_SERVER['HTTP_ACCEPT']);
         $type = null;
         if (isset($accept[0])) {
-            $response = new Response();
+            $response = new Apify_Response();
             $mimeTypes = $response->getMimeTypes();
             $type = array_search($accept[0], $mimeTypes);
             if (false === $type) {
@@ -689,17 +689,17 @@ class Request
     }
     
     /**
-     * @return Session
+     * @return Apify_Session
      */
     public function getSession()
     {
-        return Loader::getInstance()->get('Session');
+        return Apify_Loader::getInstance()->get('Session');
     }
     
     /**
      * Return the Response object
      *
-     * @return Response
+     * @return Apify_Response
      */
     public function getResponse()
     {
@@ -709,10 +709,10 @@ class Request
     /**
      * Set the Response object
      *
-     * @param Response $response
+     * @param Apify_Response $response
      * @return self
      */
-    public function setResponse(Response $response)
+    public function setResponse(Apify_Response $response)
     {
         $this->response = $response;
         return $this;
@@ -723,9 +723,9 @@ class Request
      * @param integer $code HTTP status codes
      * @return void
      */
-    public function redirect($uri, $code = Response::FOUND)
+    public function redirect($uri, $code = Apify_Response::FOUND)
     {
-        $response = new Response();
+        $response = new Apify_Response();
         $response->setCode($code);
         $response->addHeader('Location: ' . $uri);
         $response->sendHeaders();

--- a/library/Apify/Response.php
+++ b/library/Apify/Response.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Response
+class Apify_Response
 {
     const OK                  = 200; // The request has succeeded.
     const CREATED             = 201; // The request has been fulfilled and resulted in a new resource being created.
@@ -112,7 +112,7 @@ class Response
 
     /**
      * @param int $code
-     * @return Response
+     * @return Apify_Response
      */
     public function setCode($code)
     {
@@ -153,7 +153,7 @@ class Response
 
     /**
      * @param Exception $e
-     * @return Response
+     * @return Apify_Response
      * @throws Exception
      */
     public function setException(Exception $e)
@@ -218,7 +218,7 @@ class Response
     
     /**
      * @param string $type
-     * @return Response
+     * @return Apify_Response
      * @throws RuntimeException
      */
     public function setContentTypeHeader($type)
@@ -301,7 +301,7 @@ class Response
     /**
      * @param string $key
      * @param mixed $value
-     * @return Response
+     * @return Apify_Response
      * @throws RuntimeException
      */
     public function assign($key, $value)
@@ -312,7 +312,7 @@ class Response
             $this->data = new stdClass();
         }
         
-        if (is_object($value) && $value instanceof Entity) {
+        if (is_object($value) && $value instanceof Apify_Entity) {
             // use dynamic properties
             $this->data->$key = $value->toObject();
         } else {

--- a/library/Apify/Route.php
+++ b/library/Apify/Route.php
@@ -1,112 +1,11 @@
-<?php
+<?php 
 /**
  * Zend Framework
  *
  * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd New BSD License
  */
-class Router
-{
-    /**
-     * @var array Array of routes to match against
-     */
-    protected $routes = array();
-    
-    /**
-     * Add routes to the route chain
-     *
-     * @param array $routes Array of routes with names as keys and routes as values
-     */
-    public function addRoutes($routes) 
-    {
-        foreach ($routes as $name => $route) {
-            $this->routes[$name] = $route;
-        }
-    }
-
-    /**
-     * Check if named route exists
-     *
-     * @param string $name Name of the route
-     * @return boolean
-     */
-    public function hasRoute($name)
-    {
-        return isset($this->_routes[$name]);
-    }
-    
-    /**
-     * Retrieve a named route
-     *
-     * @param string $name Name of the route
-     * @return Route object
-     * @throws RuntimeException
-     */
-    public function getRoute($name)
-    {
-        if (!isset($this->routes[$name])) {
-            throw new RuntimeException("Route $name is not defined");
-        }
-        return $this->routes[$name];
-    }
-
-    /**
-     * Retrieve an array of routes added to the route chain
-     *
-     * @return array All of the defined routes
-     */
-    public function getRoutes()
-    {
-        return $this->routes;
-    }
-
-    /**
-     * Find a matching route to the current url path and inject
-     * returning values to the Request object.
-     *
-     * @return Request object
-     */
-    public function route(Request $request)
-    {
-        if (! $this->hasRoute('default')) {
-            $route = array('controller' => 'index', 'action' => 'index');
-            $compat = new RouteStatic('default', $route);
-            $this->routes = array_merge(array('default' => $compat), $this->routes);
-        }
-        
-        $urlPath = $request->getUrlPath();
-
-        foreach (array_reverse($this->routes) as $name => $route) {
-            if ($params = $route->match($urlPath)) {
-                $this->setRequestParams($request, $params);
-                break;
-            }
-        }
-
-        return $request;
-    }
-
-    public function setRequestParams($request, $params)
-    {
-        foreach ($params as $param => $value) {
-            $request->setParam($param, $value);
-            if ($param === 'controller') {
-                $request->setController($value);
-            }
-            if ($param === 'action') {
-                $request->setAction($value);
-            }
-        }
-    }
-}
-
-/**
- * Zend Framework
- *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd New BSD License
- */
-class Route
+class Apify_Route
 {
     protected $urlVariable = ':';
     protected $urlDelimiter = '/';
@@ -129,7 +28,7 @@ class Route
      * @param string $route Map used to match with later submitted URL path
      * @param array $defaults Defaults for map variables with keys as variable names
      * @param array $reqs Regular expression requirements for variables (keys as variable names)
-     */
+    */
     public function __construct($route, $defaults = array(), $reqs = array())
     {
         $route = trim($route, $this->urlDelimiter);
@@ -153,7 +52,7 @@ class Route
             }
         }
     }
-    
+
     protected function getWildcardData($parts, $unique)
     {
         $pos = count($parts);
@@ -323,7 +222,7 @@ class Route
      * @param string $name Array key of the parameter
      * @return string Previously set default
      */
-    public function getDefault($name) 
+    public function getDefault($name)
     {
         if (isset($this->defaults[$name])) {
             return $this->defaults[$name];
@@ -336,83 +235,8 @@ class Route
      *
      * @return array Route defaults
      */
-    public function getDefaults() 
+    public function getDefaults()
     {
         return $this->defaults;
     }
 }
-
-/**
- * Zend Framework
- *
- * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd New BSD License
- */
-class RouteStatic
-{
-    protected $route = null;
-    protected $defaults = array();
-
-    /**
-     * Prepares the route for mapping.
-     *
-     * @param string $route Map used to match with later submitted URL path
-     * @param array $defaults Defaults for map variables with keys as variable names
-     */
-    public function __construct($route, $defaults = array())
-    {
-        $this->route = trim($route, '/');
-        $this->defaults = (array) $defaults;
-    }
-
-    /**
-     * Matches a user submitted path with a previously defined route.
-     * Assigns and returns an array of defaults on a successful match.
-     *
-     * @param string $path Path used to match against this routing map
-     * @return array|false An array of assigned values or a false on a mismatch
-     */
-    public function match($path)
-    {
-        if (trim($path, '/') == $this->route) {
-            return $this->defaults;
-        }
-        return false;
-    }
-
-    /**
-     * Assembles a URL path defined by this route
-     *
-     * @param array $data An array of variable and value pairs used as parameters
-     * @return string Route path with user submitted parameters
-     */
-    public function assemble($data = array())
-    {
-        return $this->route;
-    }
-
-    /**
-     * Return a single parameter of route's defaults
-     *
-     * @param string $name Array key of the parameter
-     * @return string Previously set default
-     */
-    public function getDefault($name) 
-    {
-        if (isset($this->defaults[$name])) {
-            return $this->defaults[$name];
-        }
-        return null;
-    }
-
-    /**
-     * Return an array of defaults
-     *
-     * @return array Route defaults
-     */
-    public function getDefaults() 
-    {
-        return $this->defaults;
-    }
-}
-

--- a/library/Apify/RouteStatic.php
+++ b/library/Apify/RouteStatic.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Apify_RouteStatic
+{
+    protected $route = null;
+    protected $defaults = array();
+
+    /**
+     * Prepares the route for mapping.
+     *
+     * @param string $route Map used to match with later submitted URL path
+     * @param array $defaults Defaults for map variables with keys as variable names
+    */
+    public function __construct($route, $defaults = array())
+    {
+        $this->route = trim($route, '/');
+        $this->defaults = (array) $defaults;
+    }
+
+    /**
+     * Matches a user submitted path with a previously defined route.
+     * Assigns and returns an array of defaults on a successful match.
+     *
+     * @param string $path Path used to match against this routing map
+     * @return array|false An array of assigned values or a false on a mismatch
+     */
+    public function match($path)
+    {
+        if (trim($path, '/') == $this->route) {
+            return $this->defaults;
+        }
+        return false;
+    }
+
+    /**
+     * Assembles a URL path defined by this route
+     *
+     * @param array $data An array of variable and value pairs used as parameters
+     * @return string Route path with user submitted parameters
+     */
+    public function assemble($data = array())
+    {
+        return $this->route;
+    }
+
+    /**
+     * Return a single parameter of route's defaults
+     *
+     * @param string $name Array key of the parameter
+     * @return string Previously set default
+     */
+    public function getDefault($name)
+    {
+        if (isset($this->defaults[$name])) {
+            return $this->defaults[$name];
+        }
+        return null;
+    }
+
+    /**
+     * Return an array of defaults
+     *
+     * @return array Route defaults
+     */
+    public function getDefaults()
+    {
+        return $this->defaults;
+    }
+}

--- a/library/Apify/Router.php
+++ b/library/Apify/Router.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * @copyright  Copyright (c) 2005-2011 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd New BSD License
+ */
+class Apify_Router
+{
+    /**
+     * @var array Array of routes to match against
+     */
+    protected $routes = array();
+    
+    /**
+     * Add routes to the route chain
+     *
+     * @param array $routes Array of routes with names as keys and routes as values
+     */
+    public function addRoutes($routes) 
+    {
+        foreach ($routes as $name => $route) {
+            $this->routes[$name] = $route;
+        }
+    }
+
+    /**
+     * Check if named route exists
+     *
+     * @param string $name Name of the route
+     * @return boolean
+     */
+    public function hasRoute($name)
+    {
+        return isset($this->_routes[$name]);
+    }
+    
+    /**
+     * Retrieve a named route
+     *
+     * @param string $name Name of the route
+     * @return Apify_Route object
+     * @throws RuntimeException
+     */
+    public function getRoute($name)
+    {
+        if (!isset($this->routes[$name])) {
+            throw new RuntimeException("Route $name is not defined");
+        }
+        return $this->routes[$name];
+    }
+
+    /**
+     * Retrieve an array of routes added to the route chain
+     *
+     * @return array All of the defined routes
+     */
+    public function getRoutes()
+    {
+        return $this->routes;
+    }
+
+    /**
+     * Find a matching route to the current url path and inject
+     * returning values to the Request object.
+     *
+     * @return Apify_Request object
+     */
+    public function route(Apify_Request $request)
+    {
+        if (! $this->hasRoute('default')) {
+            $route = array('controller' => 'index', 'action' => 'index');
+            $compat = new Apify_RouteStatic('default', $route);
+            $this->routes = array_merge(array('default' => $compat), $this->routes);
+        }
+        
+        $urlPath = $request->getUrlPath();
+
+        foreach (array_reverse($this->routes) as $name => $route) {
+            if ($params = $route->match($urlPath)) {
+                $this->setRequestParams($request, $params);
+                break;
+            }
+        }
+
+        return $request;
+    }
+
+    public function setRequestParams($request, $params)
+    {
+        foreach ($params as $param => $value) {
+            $request->setParam($param, $value);
+            if ($param === 'controller') {
+                $request->setController($value);
+            }
+            if ($param === 'action') {
+                $request->setAction($value);
+            }
+        }
+    }
+}

--- a/library/Apify/Session.php
+++ b/library/Apify/Session.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Session
+class Apify_Session
 {
     /**
      * @var boolean

--- a/library/Apify/StringUtil.php
+++ b/library/Apify/StringUtil.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class StringUtil
+class Apify_StringUtil
 {
     /**
      * Converts a string to CamelCase.

--- a/library/Apify/View.php
+++ b/library/Apify/View.php
@@ -20,7 +20,7 @@
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class View
+class Apify_View
 {
     /**
      * @var null|string
@@ -66,7 +66,7 @@ class View
      * @param string $key
      * @param mixed $value
      * @return self
-     * @throws RuntimeException
+     * @throws Apify_RuntimeException
      */
     public function assign($key, $value)
     {
@@ -179,21 +179,21 @@ class View
     }
     
     /**
-     * @param Layout|string $layout
+     * @param Apify_Layout|string $layout
      * @return self
      */ 
     public function setLayout($layout) 
     {
-        if ($layout instanceof Layout) {
+        if ($layout instanceof Apify_Layout) {
             $this->layout = $layout;    
         } else {
-            $this->setLayout(new Layout($layout));
+            $this->setLayout(new Apify_Layout($layout));
         }
         return $this;
     }
  
     /**
-     * @return null|Layout
+     * @return null|Apify_Layout
      */ 
     public function getLayout() 
     {
@@ -243,7 +243,7 @@ class View
  * @copyright   Copyright (c) 2011 Kewnode Ltd.
  * @version     $Id: $
  */
-class Layout
+class Apify_Layout
 {
     /**
      * @var null|string

--- a/public/index.php
+++ b/public/index.php
@@ -1,11 +1,11 @@
 <?php
 define('ROOT_DIR', realpath(dirname(__FILE__) . '/../'));
-define('APP_DIR', ROOT_DIR . '/app');
+define('APP_DIR', ROOT_DIR . DIRECTORY_SEPARATOR . 'app');
 
 require_once ROOT_DIR . '/config/config.php';
 
 try {
-    $request = new Request();
+    $request = new Apify_Request();
     $request->enableUrlRewriting();
     $request->addRoutes(include ROOT_DIR.'/config/routes.php');
     $request->dispatch();


### PR DESCRIPTION
I Like Apify and the way it's build like ZF1, however one thing "missing" from ZF1is the ability to add more libraries.
Technically you can add more libraries but the entire Library folder is kinda a mess already.
I transformed all the class of Apify into a Apify Package in the library folder.
With this modification you should be able to build your own reusable libraries:
/library/MY-PACKAGE/Class.php
/library/MY-PACKAGE/Class/Subclass.php
